### PR TITLE
Add config.provider to index.ts exports

### DIFF
--- a/projects/ngx-multi-window/src/index.ts
+++ b/projects/ngx-multi-window/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/multi-window.module';
 
 export * from './lib/providers/multi-window.service';
 export * from './lib/providers/storage.service';
+export * from './lib/providers/config.provider';
 
 export * from './lib/types/message.type';
 export * from './lib/types/multi-window.config';

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,28 +1,31 @@
-import { TestBed, async } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import {TestBed, async} from '@angular/core/testing';
+import {AppComponent} from './app.component';
+import {NGXMW_CONFIG} from 'ngx-multi-window';
+import {FormsModule} from '@angular/forms';
+
+const multiWindowConfig = {
+  heartbeat: 1000,
+  newWindowScan: 1000
+};
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent,
+        AppComponent
       ],
+      providers: [
+        {provide: NGXMW_CONFIG, useValue: multiWindowConfig}
+      ],
+      imports: [
+        FormsModule
+      ]
     }).compileComponents();
   }));
-  it('should create the app', async(() => {
+
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
-  }));
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
-  }));
+  });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,21 +5,21 @@ import {FormsModule} from '@angular/forms';
 
 const multiWindowConfig = {
   heartbeat: 1000,
-  newWindowScan: 1000
+  newWindowScan: 1000,
 };
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        AppComponent
+        AppComponent,
       ],
       providers: [
-        {provide: NGXMW_CONFIG, useValue: multiWindowConfig}
+        {provide: NGXMW_CONFIG, useValue: multiWindowConfig},
       ],
       imports: [
-        FormsModule
-      ]
+        FormsModule,
+      ],
     }).compileComponents();
   }));
 


### PR DESCRIPTION
`config.provider.ts` was never exported by the npm module. Without `NGXMW_CONFIG` you can't create a testbed for Karma testing. This PR exports it and fixes https://github.com/Nolanus/ngx-multi-window/issues/39.